### PR TITLE
Scheme URI Building

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/uri/datamodel/UUri.java
+++ b/src/main/java/org/eclipse/uprotocol/uri/datamodel/UUri.java
@@ -24,8 +24,7 @@ import org.eclipse.uprotocol.uri.factory.UriFactory;
 import java.util.Objects;
 
 /**
- * Data representation of an <b> URI</b>.<br>
- * Matches the uProtocol URI in SDV-202 uProtocol Format<br>
+ * Data representation of an <b> URI</b>.
  * This class will be used to represent the source and sink (destination) parts of the  Packet CloudEvent. <br>
  * URI is used as a method to uniquely identify devices, services, and resources on the  network.<br>
  * Defining a common URI for the system allows applications and/or services to publish and discover each other

--- a/src/main/java/org/eclipse/uprotocol/uri/factory/UriFactory.java
+++ b/src/main/java/org/eclipse/uprotocol/uri/factory/UriFactory.java
@@ -46,7 +46,7 @@ public interface UriFactory {
     }
 
     /**
-     * Create the uProtocol URI with a custom scheme  for source sink and topics .
+     * Create the uProtocol URI with a custom scheme for source sink and topics.
      * 
      * API can be used to omit the scheme or use an existing proprietary scheme but 
      * keeping the same datamodel of UUri
@@ -74,6 +74,7 @@ public interface UriFactory {
         }
 
         sb.append(buildSoftwareEntityPartOfUri(Uri.uEntity()));
+        
         sb.append(buildResourcePartOfUri(Uri.uResource()));
 
         return sb.toString().replaceAll("/+$", "");
@@ -96,13 +97,13 @@ public interface UriFactory {
     
     
     /**
-     * Create a uProtocol URI string for source sink and topics from the separate parts
+     * Create a uProtocol URI with a custom scheme for source sink and topics using the separate parts
      * of an  URI.
      *
-     * @param scheme The URI scheme of this URI.
      * @param uAuthority The  Authority represents the deployment location of a specific  Software Entity in the Ultiverse.
      * @param uEntity The  Software Entity in the role of a service or in the role of an application.
      * @param uResource The resource is something that is manipulated by a service such as a Door.
+     * @param scheme The URI scheme of this URI.
      *
      * @return Returns the uProtocol URI string from an  URI data object
      *      that can be used as a sink or a source in a uProtocol publish communication.

--- a/src/main/java/org/eclipse/uprotocol/uri/factory/UriFactory.java
+++ b/src/main/java/org/eclipse/uprotocol/uri/factory/UriFactory.java
@@ -42,18 +42,41 @@ public interface UriFactory {
      *      that can be used as a sink or a source in a uProtocol publish communication.
      */
     static String buildUProtocolUri(UUri Uri) {
-        return buildUri(Uri, new StringBuilder(UUri.SCHEME));
+        return buildUProtocolUri(Uri, UUri.SCHEME);
     }
 
     /**
-     * Create the uProtocol URI string for source sink and topics from an  URI.
+     * Create the uProtocol URI with a custom scheme  for source sink and topics .
+     * 
+     * API can be used to omit the scheme or use an existing proprietary scheme but 
+     * keeping the same datamodel of UUri
      * 
      * @param Uri The  URI data object.
-     * @return Returns the uProtocol URI string from an  URI data object
+     * @param scheme The URI scheme per RFC2396.
+     * @return Returns the uProtocol URI string from an URI data object
      *      that can be used as a sink or a source in a uProtocol publish communication.
      */
-    static String buildUProtocolUri(String scheme, UUri Uri) {
-        return buildUri(Uri, new StringBuilder(scheme));
+    static String buildUProtocolUri(UUri Uri, String scheme) {
+        if (Uri == null || Uri.isEmpty()) {
+            return (scheme == null) ? new String() : scheme;
+        }
+
+        StringBuilder sb = new StringBuilder(scheme);
+
+        sb.append(buildAuthorityPartOfUri(Uri.uAuthority()));
+
+        if (Uri.uAuthority().isMarkedRemote()) {
+            sb.append("/");
+        }
+
+        if (Uri.uEntity().isEmpty()) {
+            return sb.toString();
+        }
+
+        sb.append(buildSoftwareEntityPartOfUri(Uri.uEntity()));
+        sb.append(buildResourcePartOfUri(Uri.uResource()));
+
+        return sb.toString().replaceAll("/+$", "");
     }
 
     /**
@@ -84,8 +107,8 @@ public interface UriFactory {
      * @return Returns the uProtocol URI string from an  URI data object
      *      that can be used as a sink or a source in a uProtocol publish communication.
      */
-    static String buildUProtocolUri(String scheme, UAuthority uAuthority, UEntity uEntity, UResource uResource) {
-        return buildUProtocolUri(scheme, new UUri(uAuthority, uEntity, uResource));
+    static String buildUProtocolUri(UAuthority uAuthority, UEntity uEntity, UResource uResource, String scheme) {
+        return buildUProtocolUri(new UUri(uAuthority, uEntity, uResource), scheme);
     }
 
     /**
@@ -157,36 +180,6 @@ public interface UriFactory {
         return sb.toString();
     }
 
-    /**
-     * Create the uProtocol URI string for source sink and topics from an  URI.
-     * 
-     * @param Uri The  URI data object.
-     * @return Returns the uProtocol URI string from an  URI data object
-     *      that can be used as a sink or a source in a uProtocol publish communication.
-     */
-    private static String buildUri(UUri Uri, StringBuilder sb) {
-
-        if (Uri == null || Uri.isEmpty()) {
-            return sb.toString().isEmpty() ? new String() : UUri.SCHEME;
-        }
-
-        sb.append(buildAuthorityPartOfUri(Uri.uAuthority()));
-
-        if (Uri.uAuthority().isMarkedRemote()) {
-            sb.append("/");
-        }
-
-        if (Uri.uEntity().isEmpty()) {
-            return sb.toString();
-        }
-
-        sb.append(buildSoftwareEntityPartOfUri(Uri.uEntity()));
-
-        sb.append(buildResourcePartOfUri(Uri.uResource()));
-
-        return sb.toString().replaceAll("/+$", "");
-    }
-    
 
     /**
      * Create the authority part of the uProtocol URI from an  authority object.

--- a/src/test/java/org/eclipse/uprotocol/uri/factory/UriFactoryTest.java
+++ b/src/test/java/org/eclipse/uprotocol/uri/factory/UriFactoryTest.java
@@ -918,7 +918,7 @@ class UriFactoryTest {
         UAuthority uAuthority = UAuthority.remote("VCU", "MY_CAR_VIN");
         UEntity use = new UEntity("body.access", "1");
         UResource uResource = UResource.fromName("door");
-        String ucustomUri = UriFactory.buildUProtocolUri("custom:", uAuthority, use, uResource);
+        String ucustomUri = UriFactory.buildUProtocolUri(uAuthority, use, uResource, "custom:");
         assertEquals("custom://vcu.my_car_vin/body.access/1/door", ucustomUri);
     }
     @Test
@@ -926,7 +926,7 @@ class UriFactoryTest {
     public void test_build_protocol_uri_from_custom_scheme_one() {
         String uri = "custom://VCU/body.access/1/door.front_left";
         UUri Uri = UriFactory.parseFromUri(uri);
-        String ucustomUri = UriFactory.buildUProtocolUri("custom:", Uri);
+        String ucustomUri = UriFactory.buildUProtocolUri(Uri, "custom:");
         assertEquals("custom://vcu/body.access/1/door.front_left", ucustomUri);
     }
 
@@ -936,7 +936,7 @@ class UriFactoryTest {
         UAuthority uAuthority = null;
         UEntity uSoftwareEntity = null;
         UResource uResource = null;
-        String customUri = UriFactory.buildUProtocolUri("", uAuthority, uSoftwareEntity, uResource);
+        String customUri = UriFactory.buildUProtocolUri(uAuthority, uSoftwareEntity, uResource, "");
         assertTrue(customUri.isEmpty());
     }
 
@@ -946,7 +946,7 @@ class UriFactoryTest {
         UAuthority uAuthority = UAuthority.remote("VCU", "MY_CAR_VIN");
         UEntity use = new UEntity("body.access", "1");
         UResource uResource = UResource.fromName("door");
-        String ucustomUri = UriFactory.buildUProtocolUri("", uAuthority, use, uResource);
+        String ucustomUri = UriFactory.buildUProtocolUri(uAuthority, use, uResource, "");
         assertEquals("//vcu.my_car_vin/body.access/1/door", ucustomUri);
     }
 

--- a/src/test/java/org/eclipse/uprotocol/uri/factory/UriFactoryTest.java
+++ b/src/test/java/org/eclipse/uprotocol/uri/factory/UriFactoryTest.java
@@ -37,6 +37,7 @@ class UriFactoryTest {
         assertTrue(Uri.isEmpty());
     }
 
+    
     @Test
     @DisplayName("Test parse uProtocol uri that is empty string")
     public void test_parse_protocol_uri_when_is_empty_string() {
@@ -103,7 +104,7 @@ class UriFactoryTest {
         assertEquals("access", Uri.uResource().instance().get());
         assertTrue(Uri.uResource().message().isEmpty());
     }
-
+ 
     @Test
     @DisplayName("Test parse uProtocol uri with schema and 6 slash and something")
     public void test_parse_protocol_uri_with_schema_and_6_slash_and_something() {
@@ -908,6 +909,45 @@ class UriFactoryTest {
         UResource uResource = UResource.fromName("door");
         String uProtocolUri = UriFactory.buildUProtocolUri(uAuthority, use, uResource);
         assertEquals("up://vcu.my_car_vin/body.access/1/door", uProtocolUri);
+    }
+
+    @Test
+    @DisplayName("Test Create a URI using custom scheme_separate")
+    public void test_build_protocol_uri_from_custom_scheme() {
+        String uri = "custom://VCU/body.access/1/door.front_left";
+        UAuthority uAuthority = UAuthority.remote("VCU", "MY_CAR_VIN");
+        UEntity use = new UEntity("body.access", "1");
+        UResource uResource = UResource.fromName("door");
+        String ucustomUri = UriFactory.buildUProtocolUri("custom:", uAuthority, use, uResource);
+        assertEquals("custom://vcu.my_car_vin/body.access/1/door", ucustomUri);
+    }
+    @Test
+    @DisplayName("Test Create a URI using custom scheme_one")
+    public void test_build_protocol_uri_from_custom_scheme_one() {
+        String uri = "custom://VCU/body.access/1/door.front_left";
+        UUri Uri = UriFactory.parseFromUri(uri);
+        String ucustomUri = UriFactory.buildUProtocolUri("custom:", Uri);
+        assertEquals("custom://vcu/body.access/1/door.front_left", ucustomUri);
+    }
+
+    @Test
+    @DisplayName("Test Create a URI using no scheme")
+    public void test_custom_scheme_no_scheme_empty() {
+        UAuthority uAuthority = null;
+        UEntity uSoftwareEntity = null;
+        UResource uResource = null;
+        String customUri = UriFactory.buildUProtocolUri("", uAuthority, uSoftwareEntity, uResource);
+        assertTrue(customUri.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Test Create a custom URI using no scheme")
+    public void test_custom_scheme_no_scheme() {
+        UAuthority uAuthority = UAuthority.remote("VCU", "MY_CAR_VIN");
+        UEntity use = new UEntity("body.access", "1");
+        UResource uResource = UResource.fromName("door");
+        String ucustomUri = UriFactory.buildUProtocolUri("", uAuthority, use, uResource);
+        assertEquals("//vcu.my_car_vin/body.access/1/door", ucustomUri);
     }
 
 }


### PR DESCRIPTION
Adding methods to support older/proprietary scheme or blank scheme in the URI. This does not change the datamodel of URI for uProtocol