### PR TITLE
Add build and test github action for java sdk repo

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,7 +11,7 @@ name: Java CI with Maven
 on: workflow_dispatch
 
 jobs:
-  build:
+  build-and-test:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,11 +23,9 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         cache: maven
-    - name: Build with Maven
+    - name: Build and Test with Maven
       run: mvn -B package --file pom.xml
-    - name: Test with Maven
-      run: mvn test
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    # - name: Update dependency graph
-    #  uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,5 +27,5 @@ jobs:
       run: mvn -B package --file pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+    # - name: Update dependency graph
+    #  uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,7 +8,10 @@
 
 name: Java CI with Maven
 
-on: workflow_dispatch
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-and-test:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,6 +25,8 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+    - name: Test with Maven
+      run: mvn test
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     # - name: Update dependency graph

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,31 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on: workflow_dispatch
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    # - name: Update dependency graph
+    #  uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
## What does this PR do?

Adds a build and test github action for the java sdk repo. Essentially takes the starter workflow for building with Maven (found [here](https://github.com/actions/starter-workflows/blob/main/ci/maven.yml) and comments out the optional dependency graph update as that requires some other configuration (found [here](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-the-dependency-graph)).

## Validation

Validated in forked repository that the build and test workflow executes as expected when a pull request is made into main:
![image](https://github.com/eclipse-uprotocol/uprotocol-sdk-java/assets/105753233/ad84c7b9-67c0-4968-ae72-3121ecacc378)

Here are some screenshots of the workflow running:
Build executing:
![image](https://github.com/eclipse-uprotocol/uprotocol-sdk-java/assets/105753233/4cf6a162-b4c5-4740-b578-261a933cc3a7)

Build complete and test starting:
![image](https://github.com/eclipse-uprotocol/uprotocol-sdk-java/assets/105753233/affb6275-bce6-45d3-a616-5438c0604c5f)

test completing:
![image](https://github.com/eclipse-uprotocol/uprotocol-sdk-java/assets/105753233/7f9a49f1-a4d2-4021-9b3d-8a3ba4260ef8)

Success at the end:
![image](https://github.com/eclipse-uprotocol/uprotocol-sdk-java/assets/105753233/fb476552-9dd9-4d34-9534-8517e8a50296)
