### PR TITLE
Removed unused attributes

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactory.java
+++ b/src/main/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactory.java
@@ -176,8 +176,10 @@ public interface CloudEventFactory {
         final CloudEventBuilder cloudEventBuilder = CloudEventBuilder.v1()
                 .withId(id)
                 .withSource(URI.create(source))
+                /* Not needed:
                 .withDataContentType(PROTOBUF_CONTENT_TYPE)
                 .withDataSchema(URI.create(protoPayloadSchema))
+                */
                 .withData(protoPayloadBytes);
 
         attributes.ttl().ifPresent(ttl -> cloudEventBuilder.withExtension("ttl", ttl));

--- a/src/main/java/org/eclipse/uprotocol/cloudevent/serialize/CloudEventToJsonSerializer.java
+++ b/src/main/java/org/eclipse/uprotocol/cloudevent/serialize/CloudEventToJsonSerializer.java
@@ -29,7 +29,8 @@ import io.cloudevents.jackson.JsonFormat;
  */
 public class CloudEventToJsonSerializer implements CloudEventSerializer {
 
-    private static final JsonFormat serializer = new JsonFormat();
+    // Force database64 encoding as we know the data will be in a protobuf format
+    private static final JsonFormat serializer = new JsonFormat(true, false);
 
     public byte[] serialize(CloudEvent cloudEvent) {
         return serializer.serialize(cloudEvent);


### PR DESCRIPTION
The following change removes datacontenttype and dataschema from cloudevent attributes as they are optional and not used/needed. To support this change, Jackson JSON parser needs to be explicitly told that the data is always base64 encoded.

#13