### PR TITLE
Revert default UUID to v6

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactory.java
+++ b/src/main/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactory.java
@@ -148,10 +148,10 @@ public interface CloudEventFactory {
     }
 
     /**
-     * @return Returns a UUIDv8 id.
+     * @return Returns a UUIDv6 id.
      */
     static String generateCloudEventId() {
-        UUID uuid = UUIDFactory.Factories.UPROTOCOL.factory().create();
+        UUID uuid = UUIDFactory.Factories.UUIDV6.factory().create();
         return uuid.toString();
     }
 


### PR DESCRIPTION
Production version of uProtocol (1.3.7) used UUIDv6 and changing to v8 would result in a non-backwards compatible change as CloudEvents assume v6 because of the Validators that are used in devices. In order to change versions of UUIDs, we'll need to update the message type version (ex. pub.v1 to pub.v2), something to be considered at a later date.

#15